### PR TITLE
Update plugin

### DIFF
--- a/ffbsee.net.lektorproject
+++ b/ffbsee.net.lektorproject
@@ -13,5 +13,5 @@ target = rsync://web17@c3woc.de:/var/www/clients/client10/web17/web
 
 [packages]
 lektor-atom = 0.2
-lektor-scsscompile = 1.2.1
-lektor-jsminify = 1.3
+lektor-scsscompile = 1.2.2
+lektor-jsminify = 1.4


### PR DESCRIPTION
gleich wie bei dem anderen Plugin werden jetzt beim development server die Dateien im Hintergrund beobachtet und ggfs neu gebaut

und auch hier offenbar die falsche Version von scsscompile eingetragen