### PR TITLE
csp-headers in .htaccess

### DIFF
--- a/assets/.htaccess
+++ b/assets/.htaccess
@@ -21,7 +21,7 @@ Header append X-Frame-Options "SAMEORIGIN"
 Header always edit Set-Cookie (.*) "$1; HttpOnly; Secure"
 
 # (Down-) Load only contents from allowed sources
-Header set Content-Security-Policy "default-src 'none'; script-src 'self'; connect-src 'self'; img-src 'self'; style-src 'self';"
+Header set Content-Security-Policy "default-src 'none'; script-src 'self' 'unsafe-inline'; connect-src 'self'; img-src 'self' data:; style-src 'self' 'unsafe-inline'; font-src 'self';"
 
 # Referrer Policy
 Header set Referrer-Policy "origin-when-cross-origin"


### PR DESCRIPTION
allow (additionally) inline scripts, data-imgs, inline styles and font-src

... und plötzlich zeigt der wieder bilder, schriften und inline-css-gesteuertes.